### PR TITLE
Add options flag isSpreadsheetId to 'spreadsheet/fetch2' method.

### DIFF
--- a/server/methods.js
+++ b/server/methods.js
@@ -49,15 +49,25 @@ Meteor.methods({
     check(options, Object);
     var fut = new Future(); //don't return until we're done exporting
 
-    EditGoogleSpreadsheet.load({
+    var loadOptions = {
       //debug: true,
-      spreadsheetName: spreadsheetName,
       worksheetId: worksheetId,
       oauth : {
         email: options.email,
         keyFile: pemFile
       }
-    }, function sheetReady(err, spreadsheet) {
+    }
+
+    // check type of spreadsheetName
+    if(options.isSpreadsheetId){
+      loadOptions.spreadsheetId = spreadsheetName;
+    }else{
+      loadOptions.spreadsheetName = spreadsheetName;
+    }
+
+    EditGoogleSpreadsheet.load(
+      loadOptions,
+      function sheetReady(err, spreadsheet) {
       if (err) {
         console.log(err);
         fut.return(false);


### PR DESCRIPTION
Added simple flag to define the type of spreadsheetName.

``` Js
Meteor.call("spreadsheet/fetch2", spreadsheetId, 1, {email: serviceEmail, isSpreadsheetId: true});
```
